### PR TITLE
Link to sugar-high on README is 404.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -41,7 +41,7 @@ Version *0.8.5.1* has been released.
 
 CanTango now:
 
-* supports "sugar-high 0.6":https://github.com/kristianmandrup/sugar-high.git.
+* supports "sugar-high 0.6":https://github.com/kristianmandrup/sugar-high.
 * The ability cache has been refactored
 * Activated engines are now run in specified order
 * The ability cache rules compiler (for dynamic rules caching) and Moneta cache/store are now optional (enabled via adapters)


### PR DESCRIPTION
Fix it by removing the trailing .git extension which is unnecessary.
