### PR TITLE
Remove sqlite3 dependency from default group.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Gemfile.lock
 *.sqlite3
 *.swp
 *.log
+.rvmrc
 
 spec/fixtures/config/test_permissions.yml
 # rcov generated

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ group :default do
   gem 'cancan',           '>= 1.4'
   gem 'sugar-high',       '>= 0.6.0'
   gem 'sweetloader',      '~> 0.1.0'
-  gem 'sqlite3'
   gem 'hashie',           '>= 0.4'
 
   # adapters
@@ -52,6 +51,7 @@ group :development, :test do
   gem "rspec-rails",  '>= 2.6.1'  # needed in development to expose the rails generators
   gem 'forgery',      '>= 0.3' # needed in development when using rake db:seed
   gem 'factory_girl'
+  gem 'sqlite3'
 
   # Adapters
   gem 'sourcify'

--- a/Rakefile
+++ b/Rakefile
@@ -37,8 +37,8 @@ end
 
 task :default => :test
 
-require 'rake/rdoctask'
-Rake::RDocTask.new do |rdoc|
+require 'rdoc/task'
+RDoc::Task.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 
   rdoc.rdoc_dir = 'rdoc'


### PR DESCRIPTION
There are three commits here, where my aim was to place the sqlite3 dependency into the development and test groups so as to allow for deployment to heroku.  On Heroku, in the production/default group sqlite3 will not be installed, since they only support postgres on their platform.

Two other commits address 

1) ignoring .rvmrc should someone choose to user RVM.
2) Modifying rdoc block in the rakefile to remove deprecation warning.

Feel free to cherry pick around the rakefile commit if you prefer.
