### PR TITLE
Fixed method names in permit engine base executor

### DIFF
--- a/lib/cantango/permit_engine/executor/base.rb
+++ b/lib/cantango/permit_engine/executor/base.rb
@@ -30,13 +30,13 @@ module CanTango
 
         def subject_in_role?
           return subject.send(has_role_meth, role) if subject.respond_to? has_role_meth
-          return subject.send(list_role_meth, role).include? role if subject.respond_to? has_role_meth
+          return subject.send(roles_list_meth).include? role if subject.respond_to? roles_list_meth
           false
         end
 
         def subject_in_role_group?
           return subject.send(has_role_group_meth, role) if subject.respond_to? has_role_group_meth
-          return subject.send(list_role_group_meth).include? role if subject.respond_to? list_role_group_meth
+          return subject.send(role_groups_list_meth).include? role if subject.respond_to? role_groups_list_meth
           false
         end
 

--- a/spec/cantango/permit_engine/executor/base_spec.rb
+++ b/spec/cantango/permit_engine/executor/base_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+require 'cantango/rspec/matchers'
+require 'fixtures/models'
+require 'cantango/rspec/matchers'
+
+class CustomerRolePermit < CanTango::RolePermit
+  def initialize ability
+    super
+  end
+
+  protected
+
+  def permit_rules
+    can :read, Article
+  end
+end
+
+class SimpleUser
+  attr_accessor :roles_list
+
+  def initialize
+    @roles_list = [:customer]
+  end
+
+  def role_groups_list
+    []
+  end
+end
+
+describe CanTango::PermitEngine::Executor::Base do
+  let (:user) do
+    SimpleUser.new
+  end
+
+  let (:ability) do
+    @ability ||= CanTango::Ability.new user
+  end
+
+  let (:permit) do
+    CustomerRolePermit.new ability
+  end
+
+  let (:executor) do
+    CanTango::PermitEngine::Executor::Base.new permit
+  end
+
+  before(:each) do
+    CanTango.config.permits.set :on
+  end
+
+  describe '#execute!' do
+    before:each do
+      CanTango.config.permits.set :on
+    end
+
+    describe 'should find permit based on #roles_list' do
+      specify { lambda{ executor.execute! }.should_not raise_error }
+    end
+
+    describe 'should search permit based on #role_groups_list' do
+      before do
+        user.roles_list.clear
+      end
+      specify { lambda{ executor.execute! }.should_not raise_error }
+    end
+  end
+end


### PR DESCRIPTION
I have run into an issue, when I have only defined a `roles_list` and `role_groups_list` methods on my user, added a `RolePermit` and then the `PermitEngine` used `Executer::Base` which crashed trying to use wrong methods.
Didn't look into the history, maybe it was missed during refactoring.
