### PR TITLE
Fix: Rails app fails to start after bundling latest CanTango

### DIFF
--- a/lib/cantango/rails/helpers/rest_helper.rb
+++ b/lib/cantango/rails/helpers/rest_helper.rb
@@ -7,7 +7,7 @@ module CanTango::Rails::Helpers::RestHelper
     }
   end
 
-  def link_to_new obj user_type, options = {}
+  def link_to_new obj, user_type, options = {}
     clazz = obj.kind_of?(Class) ? obj : obj.class
     return unless can_perform_action?(user_type, :create, clazz)
     # use i18n translation on label

--- a/lib/cantango/users/macros.rb
+++ b/lib/cantango/users/macros.rb
@@ -3,12 +3,14 @@ class Module
     self.send :include, CanTango::Users::User
     self.send :include, CanTango::Users::Masquerade if options[:masquerade]
   end
+  alias_method :cantango_user, :tango_user
 
   def tango_user_account options = {}
     self.send :include, CanTango::Users::UserAccount
     self.send :include, CanTango::Users::Masquerade if options[:masquerade]
   end
   alias_method :tango_account, :tango_user_account 
+  alias_method :cantango_account, :tango_user_account
 
   def masquerader
     self.send :include, CanTango::Users::Masquerade


### PR DESCRIPTION
=> Booting WEBrick
=> Rails 3.1.1 application starting in development on http://0.0.0.0:3000
=> Call with -d to detach
=> Ctrl-C to shutdown server
Exiting
/home/stanislaw/.rvm/gems/ruby-1.9.2-p180@310/gems/cantango-0.9.2.2/lib/cantango/rails/helpers/base_helper.rb:7:in `included': 
/home/stanislaw/.rvm/gems/ruby-1.9.2-p180@310/gems/cantango-0.9.2.2/lib/cantango/rails/helpers/rest_helper.rb:10: syntax error, unexpected 
tIDENTIFIER, expecting ';' or '\n' (SyntaxError)
  def link_to_new obj user_type, options = {}
                               ^
/home/stanislaw/.rvm/gems/ruby-1.9.2-p180@310/gems/cantango-0.9.2.2/lib/cantango/rails/helpers/rest_helper.rb:52: syntax error, unexpected 
keyword_end, expecting $end
    from /home/stanislaw/.rvm/gems/ruby-1.9.2-p180@310/gems/cantango-0.9.2.2/lib/cantango/rails/helpers/controller_helper.rb:5:in`include'
    from /home/stanislaw/.rvm/gems/ruby-1.9.2-p180@310/gems/cantango-0.9.2.2/lib/cantango/rails/helpers/controller_helper.rb:5:in 
`module:ControllerHelper'
