### PR TITLE
Fix add_role_system trying to merge wrong object

### DIFF
--- a/lib/cantango/configuration/roles.rb
+++ b/lib/cantango/configuration/roles.rb
@@ -19,7 +19,7 @@ module CanTango
 
       def add_role_system role_system_hash
         raise ArgumentError, "Must be a hash fx :troles => :role_list, was: #{role_system_hash}" if !role_system_hash.kind_of?(Hash)
-        roles_list_map.merge! role_system
+        roles_list_map.merge! role_system_hash
       end
 
       def default_has_method


### PR DESCRIPTION
add_role_system tries to merge role_system, rather than it's argument role_system_hash, which predictably results in:

 can't convert Symbol into Hash
 gems/cantango-0.9.4.7/lib/cantango/configuration/roles.rb:22:in `merge!'
