### PR TITLE
Concatenate lists to lists instead of appending them

### DIFF
--- a/lib/cantango/ability/engine_helpers.rb
+++ b/lib/cantango/ability/engine_helpers.rb
@@ -4,7 +4,7 @@ module CanTango
       def execute_engines!
         each_engine do |engine|
           engine_rules = engine.new(self).execute! if engine
-          @rules << engine_rules if !engine_rules.blank?
+          @rules += engine_rules if !engine_rules.blank?
         end
       end
 

--- a/lib/cantango/configuration/registry.rb
+++ b/lib/cantango/configuration/registry.rb
@@ -28,8 +28,8 @@ module CanTango
       end
 
       def register *list
-        registered << list.select_kinds_of(*types)
-        registered.flat_uniq!
+        registered += list.select_kinds_of(*types)
+        registered.uniq!
       end
 
       alias_method :<<, :register
@@ -52,5 +52,3 @@ module CanTango
     end
   end
 end
-
-

--- a/lib/cantango/permit_engine.rb
+++ b/lib/cantango/permit_engine.rb
@@ -15,7 +15,7 @@ module CanTango
       # push result of each permit type execution into main ability rules array
       permits.each_pair do |type, permits|
         perm_rules = executor(type, permits).execute!
-        rules << perm_rules if !perm_rules.blank?
+        rules += perm_rules if !perm_rules.blank?
       end
     end
 

--- a/lib/cantango/permits/permit.rb
+++ b/lib/cantango/permits/permit.rb
@@ -80,8 +80,7 @@ module CanTango
       end
 
       def ability_sync!
-        ability_rules << (rules - ability_rules)
-        ability_rules.flatten!
+        ability_rules += (rules - ability_rules)
       end
 
       protected

--- a/lib/cantango/permits/role_group_permit/builder.rb
+++ b/lib/cantango/permits/role_group_permit/builder.rb
@@ -45,9 +45,9 @@ module CanTango
         # for that role group will be run
         def matching_role_groups_for roles
           roles.inject([]) do |groups, role|
-            groups << subject.role_groups_for(role) if subject.respond_to?(:role_groups_for)
+            groups += subject.role_groups_for(role) if subject.respond_to?(:role_groups_for)
             groups
-          end.flatten.compact.uniq
+          end.compact.uniq
         end
 
         def role_groups_filter?

--- a/lib/cantango/user_ac_engine.rb
+++ b/lib/cantango/user_ac_engine.rb
@@ -14,7 +14,7 @@ module CanTango
           thing.nil? || permission.thing_id.nil? || permission.thing_id == thing.id
         end
       end
-      rules << ability_rules if !ability_rules.blank?
+      rules += ability_rules if !ability_rules.blank?
     end
 
     def valid?


### PR DESCRIPTION
I was trying to figure out why @rules in the class CanCan::Abilility was in a list-of-lists; it turns out it was because engine_rules is appended instead of being concatenated in lib/cantango/ability/engine_helpers.rb:7.

I have not had the time to set up a testing environment to check this, but I suspect the elementary nature of the changes should speak for themselves.

I have not had a chance to look at cantango-permits and cantango-roles, do those modules have similar issues?
